### PR TITLE
feat(generic-relay): publish assaf branch to artifactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 /website/src/relay/docs
 /website/src/relay/graphql
 /website/src/relay/prototyping
+.idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,9 +10,9 @@
 'use strict';
 
 var babel = require('gulp-babel');
-var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
-var babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
-var babelPluginAutoImporter = require('fbjs-scripts/babel/auto-importer');
+var babelPluginDEV = require('babel-preset-fbjs/plugins/dev-expression'); //require('fbjs-scripts/babel/dev-expression');
+var babelPluginModules = require('babel-preset-fbjs/plugins/rewrite-modules'); //require('fbjs-scripts/babel/rewrite-modules');
+var babelPluginAutoImporter = require('babel-preset-fbjs/plugins/auto-importer'); //require('fbjs-scripts/babel/auto-importer');
 var del = require('del');
 var derequire = require('gulp-derequire');
 var flatten = require('gulp-flatten');
@@ -83,7 +83,7 @@ var buildDist = function(opts) {
     plugins: [
       new webpackStream.webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(
-          opts.debug ? 'development' : 'production'
+            opts.debug ? 'development' : 'production'
         ),
       }),
       new webpackStream.webpack.optimize.OccurenceOrderPlugin(),
@@ -92,13 +92,13 @@ var buildDist = function(opts) {
   };
   if (!opts.debug) {
     webpackOpts.plugins.push(
-      new webpackStream.webpack.optimize.UglifyJsPlugin({
-        compress: {
-          hoist_vars: true,
-          screw_ie8: true,
-          warnings: false,
-        },
-      })
+        new webpackStream.webpack.optimize.UglifyJsPlugin({
+          compress: {
+            hoist_vars: true,
+            screw_ie8: true,
+            warnings: false,
+          },
+        })
     );
   }
   return webpackStream(webpackOpts, null, function(err, stats) {
@@ -128,10 +128,10 @@ gulp.task('clean', function(cb) {
 
 gulp.task('modules', function() {
   return gulp
-    .src(paths.src)
-    .pipe(babel(babelOpts))
-    .pipe(flatten())
-    .pipe(gulp.dest(paths.lib));
+      .src(paths.src)
+      .pipe(babel(babelOpts))
+      .pipe(flatten())
+      .pipe(gulp.dest(paths.lib));
 });
 
 gulp.task('dist', ['modules'], function() {
@@ -140,26 +140,26 @@ gulp.task('dist', ['modules'], function() {
     output: 'relay.js',
   };
   return gulp.src(paths.entry)
-    .pipe(buildDist(distOpts))
-    .pipe(derequire())
-    .pipe(header(DEVELOPMENT_HEADER, {
-      version: process.env.npm_package_version,
-    }))
-    .pipe(gulp.dest(paths.dist));
+      .pipe(buildDist(distOpts))
+      .pipe(derequire())
+      .pipe(header(DEVELOPMENT_HEADER, {
+        version: process.env.npm_package_version,
+      }))
+      .pipe(gulp.dest(paths.dist));
 });
 
-gulp.task('dist:min', ['modules'], function() {
-  var distOpts = {
-    debug: false,
-    output: 'relay.min.js',
-  };
-  return gulp.src(paths.entry)
-    .pipe(buildDist(distOpts))
-    .pipe(header(PRODUCTION_HEADER, {
-      version: process.env.npm_package_version,
-    }))
-    .pipe(gulp.dest(paths.dist));
-});
+// gulp.task('dist:min', ['modules'], function() {
+//   var distOpts = {
+//     debug: false,
+//     output: 'relay.min.js',
+//   };
+//   return gulp.src(paths.entry)
+//     .pipe(buildDist(distOpts))
+//     .pipe(header(PRODUCTION_HEADER, {
+//       version: process.env.npm_package_version,
+//     }))
+//     .pipe(gulp.dest(paths.dist));
+// });
 
 // gulp.task('website:check-version', function(cb) {
 //   var version = require('./package').version;

--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   "scripts": {
     "build": "gulp",
     "lint": "eslint .",
-    "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
     "update-schema": "babel-node ./scripts/jest/updateSchema.js"
   },
   "dependencies": {
+    "babel-preset-fbjs": "^3.4.0",
     "babel-runtime": "5.8.24",
-    "fbjs": "^0.5.1"
+    "fbjs": "3.0.5"
   },
   "peerDependencies": {
-    "babel-relay-plugin": "0.6.3"
+    "babel-relay-plugin": "0.7.3"
   },
   "devDependencies": {
     "babel": "^5.8.25",
@@ -41,8 +41,8 @@
     "del": "^1.2.0",
     "eslint": "^1.3.1",
     "eslint-plugin-react": "^3.3.1",
-    "fbjs-scripts": "^0.5.0",
-    "flow-bin": "0.20.1",
+    "fbjs-scripts": "3.0.1",
+    "flow-bin": "0.220.1",
     "graphql": "0.4.13",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
@@ -57,8 +57,13 @@
     "webpack-stream": "^2.1.0"
   },
   "devEngines": {
-    "node": "4.x",
-    "npm": "2.x"
+    "node": "20.x",
+    "npm": "10.x"
+  },
+  "overrides": {
+    "gulp": {
+      "vinyl-fs": "4.0.0"
+    }
   },
   "jest": {
     "rootDir": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "generic-relay",
+  "name": "@forter/generic-relay",
   "description": "A modified version of Relay to work without React",
-  "version": "0.1.0",
+  "version": "0.1.0-assaf-nodejs20",
   "keywords": [
     "graphql",
     "react",


### PR DESCRIPTION
asana: https://app.asana.com/1/7840801737159/project/23095211578528/task/1216016603847058
Publishes generic-relay to Artifactory as `@forter/generic-relay@0.1.0-assaf-nodejs20`.

This allows portal to reference it from the registry instead of a git URL, which is required for `allow-git=none` in the supply chain hardening migration.